### PR TITLE
Update to flash messages and changed root endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -892,7 +892,7 @@ def index():
     active = Users.query.filter_by(id=user).first()
     
     if not active:
-        return redirect(url_for("login"))
+        return render_template("login.html")
     elif active.account_type == 'instructor':
         return redirect(url_for('instructor_home'))
     else:

--- a/templates/login.html
+++ b/templates/login.html
@@ -15,19 +15,26 @@
  
   <body class="text-center">
 	  <!--TODO:  UPDATE THIS BLOCK STYLING-->
-	<div class='msg_flash'>
-		{% with messages = get_flashed_messages() %}
-  			{% if error %}
-         		<h6>Error: {{ error }} </h6>
-			{% endif %}
-			{% if message %}
-			  <h6> {{message}}</h6>
-			{% endif %}
-		{% endwith %}
-	</div>
+	
     <form class="form-signin" action="/login" method="post">
       	<img class="mb-4" src="../static/images/ualr_logo.png" alt="" height="70">
       	<h1 class="h3 mb-3 font-weight-normal">ATAS Login</h1>
+		<div class='msg_flash'>
+			{% with messages = get_flashed_messages() %}
+				{% if error %}
+					<div class="alert alert-danger alert-dismissible" role="alert">
+		  				<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">×</span></button>
+						{{error}}
+		  			</div>
+				{% endif %}
+				{% if message %}
+				  	<div class="alert alert-success alert-dismissible" role="alert">
+		  				<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">×</span></button>
+						{{message}}
+		  			</div>
+				{% endif %}
+			{% endwith %}
+		</div>
       	<input type="email" id="email" name="email" class="form-control" placeholder="Email" required autofocus>
       	<input type="password" id="inputPassword" name="password" class="form-control" placeholder="Password" required>
       	<button class="btn btn-lg btn-block" type="submit">Sign in</button>

--- a/templates/login.html
+++ b/templates/login.html
@@ -14,8 +14,6 @@
   </head>
  
   <body class="text-center">
-	  <!--TODO:  UPDATE THIS BLOCK STYLING-->
-	
     <form class="form-signin" action="/login" method="post">
       	<img class="mb-4" src="../static/images/ualr_logo.png" alt="" height="70">
       	<h1 class="h3 mb-3 font-weight-normal">ATAS Login</h1>

--- a/templates/register.html
+++ b/templates/register.html
@@ -14,16 +14,26 @@
   </head>
  
   <body class="text-center">
-	<div class='msg_flash'>
-		{% with messages = get_flashed_messages() %}
-  			{% if error %}
-         		<h6>Error: {{ error }} </h6>
-			{% endif %}
-		{% endwith %}
-	</div>
     <form class="form-register" action="/register" method="post">
       	<img class="mb-4" src="../static/images/ualr_logo.png" alt="" height="70">
       	<h1 class="h3 mb-3 font-weight-normal">ATAS Registration</h1>
+		
+		<div class='msg_flash'>
+			{% with messages = get_flashed_messages() %}
+				{% if error %}
+					<div class="alert alert-danger alert-dismissible" role="alert">
+		  				<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">×</span></button>
+						{{error}}
+		  			</div>
+				{% endif %}
+				{% if message %}
+				  	<div class="alert alert-success alert-dismissible" role="alert">
+		  				<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">×</span></button>
+						{{message}}
+		  			</div>
+				{% endif %}
+			{% endwith %}
+		</div>
 		
 		<div class="form-row">
 			<div class="form-group col">


### PR DESCRIPTION
I updated the flash messages in login.html and register.html to use bootstrap alerts. I moved the alert under the main title of each of these pages. (Feel free to move it if you feel it looks better elsewhere!)

I also made a minor change to the root "/" endpoint in the "if not active: " section. When using the redirect to login, it was running the login endpoint, making the browser submit an empty login form. This made an error message pop up before the user had a chance to type anything in. I changed this to simply render the login.html template in this case.