### PR TITLE
UI updates

### DIFF
--- a/app.py
+++ b/app.py
@@ -131,7 +131,8 @@ def home():
         semesters_list = get_instructor_courses(user_id)
         return render_template("inst_home.html", current_user=user, semesters=semesters_list)
     elif user.account_type == 'root':
-        return render_template("root_home.html", current_user=user, user_list=user_list)
+        semesters_list = get_all_courses()
+        return render_template("root_home.html", current_user=user, user_list=user_list, semesters=semesters_list)
     else:
         semesters_list = get_all_courses()
         return render_template("home.html", current_user=user, semesters=semesters_list)
@@ -309,7 +310,7 @@ def get_instructors():
             instructor_data['last_name'] = instructor.lname
             results.append(instructor_data)
 
-        return jsonify(results)
+        return results
 
 
 # GET ONE INSTRUCTORS INFO
@@ -602,6 +603,7 @@ def get_all_courses():
                     course_data['department'] = course.department
                     course_data['course_number'] = course.course_number
                     course_data['section'] = course.section
+                    course_data['year'] = course.year
                     course_data['course_name'] = course.course_name
                     course_data['instructor_id'] = course.instructor
                     courses.append(course_data)
@@ -619,8 +621,10 @@ def get_all_courses():
 def edit_courses():
     if request.method == "GET":
         all_courses = get_all_courses()
+        instructors = get_instructors()
         print(all_courses)
-        return render_template('edit_courses.html', courses = all_courses, semesters=all_courses)
+        print(instructors)
+        return render_template('edit_courses.html', courses = all_courses, semesters=all_courses, instructors=instructors)
 
 
 @app.route('/courses/<int:course_id>', methods=['GET'])
@@ -745,8 +749,9 @@ def update_courses(course_id):
             # return render_template('/home')
 
         print('Course Updated!')
-        return redirect(url_for('get_all_courses'))
+        #return redirect(url_for('get_all_courses'))
         # return redirect(url_for('home'))
+        return redirect(url_for('edit_courses'))
 
 
 @app.route('/courses', methods=['GET', 'POST'])

--- a/templates/courses.html
+++ b/templates/courses.html
@@ -59,80 +59,39 @@
     	</div><!--END NAV CONTAINER-->
       </nav>
 	  <div class="main_content">
-		<h2 class="text-center">{{courses[0].course_department}} {{courses[0].course_number}} {{courses[0].course_name}}</h2>
-		
-		<!-- TODO: update tables to pull real information from database and create related modals -->
-		<!-- Collapsable table views -->
-		<div id="collapse-container">
-			<div class="text-center mb-2">
-				<button type="button" class="btn btn-sm btn-secondary" data-toggle="collapse" data-target="#student-view">View Students</button>
-
-				<button type="button" class="btn btn-sm btn-secondary" data-toggle="collapse" data-target="#swp-view">View Work Products</button>
-			</div>
-			
-			<!-- Student View -->
-			<div class="collapse" id="student-view" data-parent="#collapse-container">
-				<h4 class="text-center">Students</h4>
-				<div class="table-responsive">
-					<table class="table table-bordered mx-auto w-auto text-center">
-						<thead>
-							<tr>
-								<th scope="col">Student Name</th>
-								<th scope="col">Student ID</th>
-								{% if swps %}
-									{% for swp in swps %}
-										<th><a data-toggle="modal" href="#edit-swp-modal{{swp.swp_id}}">{{swp.swp_name}}</a></th>
-									{% endfor %}
-								{% endif %}
-							</tr>
-						</thead>
-						<tbody>
-							{% for student in students %}
-								<tr>
-									<td><a data-toggle="modal" href="#edit-student-modal">{{student.student_first}} {{student.student_last}}</a></td>
-									<td>{{student.student_id}}</td>
-									{% if student.student_scores %}
-										{% for score in student.student_scores %}
-											<td>{{score.score}}</td>
-										{% endfor%}
-									{% endif %}
-								</tr>
+		  <div class="text-center">
+				<h2 class="text-center">{{courses[0].course_department}} {{courses[0].course_number}} {{courses[0].course_name}}</h2>
+				<button type="button" class="btn btn-secondary mb-1">Edit Scores</button>
+		  </div>
+		<div class="table-responsive">
+			<table class="table table-bordered mx-auto w-auto text-center">
+				<thead>
+					<tr>
+						<th scope="col">Student Name</th>
+						<th scope="col">Student ID</th>
+						{% if swps %}
+							{% for swp in swps %}
+								<th><a data-toggle="modal" href="#edit-swp-modal{{swp.swp_id}}">{{swp.swp_name}}</a></th>
 							{% endfor %}
-						</tbody>
-					</table>
-				</div>
-			</div>
-			
-			<!-- SWP View -->
-			<div class="collapse" id="swp-view" data-parent="#collapse-container">
-				<h4 class="text-center">Student Work Products</h4>
-				<div class="table-responsive">
-					<table class="table table-bordered mx-auto w-auto text-center">
-						<thead>
-							<tr>
-								<th scope="col">SWP Name</th>
-								<th scope="col">SWP ID</th>
-							</tr>
-						</thead>
-						<tbody>
-							{% if swps %}				
-								{% for swp in swps %}
-									<tr>
-										<td><a data-toggle="modal" href="#edit-swp-modal{{swp.swp_id}}">{{swp.swp_name}}</a></td>
-										<td>{{swp.swp_id}}</td>
-									</tr>
-									{% endfor %}
-							{% else %}
-							<tr>
-								<td><a data-toggle="modal" href="#add-swp-modal">Add Work Product</a></td>
-							</tr>
+						{% endif %}
+					</tr>
+				</thead>
+				<tbody>
+					{% for student in students %}
+						<tr>
+							<td><a data-toggle="modal" href="#edit-student-modal{{student.student_id}}">{{student.student_first}} {{student.student_last}}</a></td>
+							<td>{{student.student_id}}</td>
+							{% if student.student_scores %}
+								{% for score in student.student_scores %}
+									<td>{{score.score}}</td>
+								{% endfor%}
 							{% endif %}
-						</tbody>
-					</table>
-				</div>
-			</div>
+						</tr>
+					{% endfor %}
+				</tbody>
+			</table>
 		</div>
-	</div>
+	  </div>
 	
 	<!-- Modals -->
 

--- a/templates/edit_courses.html
+++ b/templates/edit_courses.html
@@ -26,7 +26,7 @@
       		</button>
       		<div class="collapse navbar-collapse" id="navbarResponsive">
 				<div class="navbar-nav ml-auto">
-					<a class="nav-item nav-link active" href="/home">Home</a>
+					<a class="nav-item nav-link" href="/home">Home</a>
 					<!--COURSES DROPDOWN-->   
 					<div class="nav-item dropdown">
 					   <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Courses</a>
@@ -44,7 +44,7 @@
 				   </div>
 					<a class="nav-item nav-link" href="/outcomes">Student Outcomes</a>
 					<div class="nav-item dropdown">
-						<a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Administrative Tasks</a>
+						<a class="nav-link dropdown-toggle active" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Administrative Tasks</a>
 						<div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
 							<a class="dropdown-item" href="/courses/edit">Edit Courses</a>							
 							<a class="dropdown-item" data-toggle="modal" href="#add-swp-modal">Add Student Work Products</a>
@@ -59,38 +59,42 @@
 	  </nav>
 	  <div>
       {% if courses %}
-        <h2>Edit Courses</h2><button bclass="btn btn-primary btn-lg" data-toggle="modal" data-target="#add-course-modal">Add New Course</button>
-        <table class="table table-bordered mx-auto w-auto text-center">
-          {% for course in courses %}
-            <thead>
-                <tr>
-                    <th colspan = "6" scope="col">{{course.term}} {{course.year}}</th>
-                </tr>
-                <tr>
-                    <th>Department</th>
-                    <th>Course Number</th>
-                    <th>Section</th>
-                    <th>Course Name</th>
-                    <th>Instructor</th>
-                    <th></th>
-                </tr>
-            </thead>
-            {% if course.course_list %}
-            <tbody>
-                {%for course in course.course_list%}
-                <tr>
-                    <td>{{course.department}}</td>
-                    <td>{{course.course_number}}</td>
-                    <td>{{course.section}}</td>
-                    <td>{{course.course_name}}</td>
-                    <td>{{course.instructor_id}}</td>
-                    <td><button >Edit </button><button>Delete</button></td>
-                </tr>
-                {% endfor %}
-            </tbody>
-            {% endif %}
-          {% endfor %}
-        </table>
+        <div class="text-center mb-1">
+            <h2>Edit Courses</h2><button class="btn btn-secondary" data-toggle="modal" data-target="#add-course-modal">Add New Course</button>
+        </div>
+		<div class="table-responsive">
+			<table class="table table-bordered mx-auto w-auto text-center">
+			  {% for course in courses %}
+				<thead>
+					<tr>
+						<th colspan = "6" scope="col">{{course.term}} {{course.year}}</th>
+					</tr>
+					<tr>
+						<th>Department</th>
+						<th>Course Number</th>
+						<th>Section</th>
+						<th>Course Name</th>
+						<th>Instructor</th>
+						<th></th>
+					</tr>
+				</thead>
+				{% if course.course_list %}
+				<tbody>
+					{%for course in course.course_list%}
+					<tr>
+						<td>{{course.department}}</td>
+						<td>{{course.course_number}}</td>
+						<td>{{course.section}}</td>
+						<td>{{course.course_name}}</td>
+						<td>{{course.instructor_id}}</td>
+						<td><button class="btn btn-secondary" data-toggle="modal" data-target="#edit-course-modal{{course.course_id}}">Edit</button><button class="btn btn-secondary" data-toggle="modal" data-target="#delete-course-modal{{course.course_id}}">Delete</button></td>
+					</tr>
+					{% endfor %}
+				</tbody>
+				{% endif %}
+			  {% endfor %}
+			</table>
+		</div>
         {% endif %}
 	  </div>
 	  <!-- Modals -->
@@ -108,17 +112,20 @@
 			</div>
 			
 			<!-- Modal body -->
-            <div class="modal-lg">.
-				<form action="{{url_for('add_courses')}}" class="modal-form" method="post">
+            <div class="modal-lg">
+				<form action="{{url_for('add_courses')}}" class="modal-form m-2" method="post">
                         <div class="text-center">    
                              <div class="form-row">
                                 <div class="form-group col">
-                                    <label for="course_name">Term</label>
-                                    <input type="text" class="form-control" id="term" name="term" placeholder="ex: SPRING" required="true">
+                                    <label for="term">Term</label>
+                                    <select class="form-control" id="term" name="term" required="true">
+                                        <option value="FALL">FALL</option>
+                                        <option value="SPRING">SPRING</option>
+                                    </select>
                                 </div>
                 
                                 <div class="form-group col">
-                                    <label for="instructor">Year</label>
+                                    <label for="year">Year</label>
                                     <input type="text" class="form-control" id="year" name="year" placeholder="YYYY" required="true">
                                 </div>
                             </div>             
@@ -146,8 +153,14 @@
                                 </div>
                 
                                 <div class="form-group col">
-                                    <label for="instructor_id">Instructor ID</label>
-                                    <input type="text" class="form-control" id="instructor_id" name="instructor_id" placeholder="Instructor ID" required="true">
+                                    <label for="instructor_id">Instructor</label>
+                                    <select class="form-control" id="instructor_id" name="instructor_id" required="true">
+                                        {% if instructors %}
+                                            {% for instructor in instructors %}
+                                                <option value="{{instructor.instructor_id}}">{{instructor.last_name}}, {{instructor.first_name}} ({{instructor.instructor_id}})</option>
+                                            {% endfor %}
+                                        {% endif %}
+                                    </select>
                                 </div>
                             </div>                            
                             <button class="btn btn-secondary btn-lg btn-block" type="submit">Save</button>
@@ -157,12 +170,136 @@
 
 			<!-- Modal footer -->
 			<div class="modal-footer">                
-                  <button onclick="location.href='/courses/edit'" class="btn btn-secondary">Cancel</button>
-				  <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                  <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
 			</div>
 		  </div>
 	  </div>
 	  </div>
+	  
+	  <!-- Edit Course Modal(generated for every course) -->
+	  {% if courses %}
+	  		{% for course in courses %}
+	  			{% if course.course_list %}
+	  				{% for course in course.course_list %}
+						  <div class="modal fade" id="edit-course-modal{{course.course_id}}">
+							<div class="modal-dialog">
+							  <div class="modal-content">
+
+								<!-- Modal Header -->
+								<div class="modal-header">
+									<h4 class="modal-title">Edit {{course.department}} {{course.course_number}}: {{course.section}}</h4>
+									<button type="button" class="close" data-dismiss="modal">×</button>
+								</div>
+
+								<!-- Modal body -->
+								<div class="modal-lg">
+									<form action="{{url_for('update_courses', course_id=course.course_id)}}" class="modal-form m-2" method="post">
+											<div class="text-center">    
+												 <div class="form-row">
+													<div class="form-group col">
+														<label for="course_name">Term</label>
+														<select class="form-control" id="instructor_id" name="term" required="true">
+															{% if course.term == "FALL" %}
+															<option value="FALL" selected>FALL</option>
+															<option value="SPRING">SPRING</option>
+															{% else %}
+															<option value="FALL">FALL</option>
+															<option value="SPRING" selected>SPRING</option>
+															{% endif %}
+														</select>
+													</div>
+
+													<div class="form-group col">
+														<label for="year">Year</label>
+														<input type="text" class="form-control" id="year" name="year" placeholder="YYYY" value="{{course.year}}" required="true">
+													</div>
+												</div>             
+												<div class="form-row">
+													<div class="form-group col">
+														<label for="deparment">Department</label>
+														<input type="text" class="form-control" id="department" name="department" placeholder="ex. CPSC" value="{{course.department}}" required="true">
+													</div>
+
+													<div class="form-group col">
+														<label for="course_number">Course Number</label>
+														<input type="text" class="form-control" id="course_number" name="course_number" placeholder="ex. 1310" value="{{course.course_number}}" required="true">
+													</div>
+
+													<div class="form-group col">
+														<label for="section">Section</label>
+														<input type="test" class="form-control" id="section" name="section" placeholder="ex. 1" value="{{course.section}}" required="true">
+													</div>
+												</div>
+
+												<div class="form-row">
+													<div class="form-group col">
+														<label for="course_name">Course Name</label>
+														<input type="text" class="form-control" id="course_name" name="course_name" placeholder="Course Name" value="{{course.course_name}}" required="true">
+													</div>
+
+													<div class="form-group col">
+														<label for="instructor_id">Instructor</label>
+														<select class="form-control" id="instructor_id" name="instructor_id" required="true">
+															{% if instructors %}
+																{% for instructor in instructors %}
+																	{% if instructor.instructor_id == course.instructor_id %} <!-- if current course instructor, apply selected attr to option -->
+																	<option value="{{instructor.instructor_id}}" selected>{{instructor.last_name}}, {{instructor.first_name}} ({{instructor.instructor_id}})</option>
+																	{% else %}
+																	<option value="{{instructor.instructor_id}}">{{instructor.last_name}}, {{instructor.first_name}} ({{instructor.instructor_id}})</option>
+																	{% endif %}
+																{% endfor %}
+															{% endif %}
+														</select>
+													</div>
+												</div>                            
+												<button class="btn btn-secondary btn-lg btn-block" type="submit">Save</button>
+											</div>
+										</form>
+								</div>
+					<!-- Modal footer -->
+					<div class="modal-footer">                
+						  <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+					</div>
+				  </div>
+			  </div>
+			  </div>
+	  			{% endfor %}
+	  		{% endif %}
+	  		{% endfor %}
+	  {% endif %}
+	  
+	  <!-- Delete Course Modal(generated for every course) -->
+	  {% if courses %}
+	  		{% for course in courses %}
+	  			{% if course.course_list %}
+	  				{% for course in course.course_list %}
+						  <div class="modal fade" id="delete-course-modal{{course.course_id}}">
+							<div class="modal-dialog">
+							  <div class="modal-content">
+
+								<!-- Modal Header -->
+								<div class="modal-header">
+									<h4 class="modal-title">Delete {{course.department}} {{course.course_number}}: {{course.section}}?</h4>
+									<button type="button" class="close" data-dismiss="modal">×</button>
+								</div>
+
+								<!-- Modal body -->
+								<div class="modal-lg">
+									<h5 class="text-center m-2">Are you sure you want to delete this course? All course information will be lost!</h5>
+								</div>
+					<!-- Modal footer -->
+					<div class="modal-footer">                
+						<button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+						<button onclick="location.href='{{ url_for('delete_course', course_id = course.course_id)}}'" class="btn btn-secondary">DELETE</button>
+					</div>
+				  </div>
+			  </div>
+			  </div>
+	  			{% endfor %}
+	  		{% endif %}
+	  		{% endfor %}
+	  {% endif %}
+	  
 	  <!-- Add SWP Modal -->
 	  <div class="modal fade" id="add-swp-modal">
 		<div class="modal-dialog">

--- a/templates/inst_courses.html
+++ b/templates/inst_courses.html
@@ -61,80 +61,39 @@
 	  </nav>
 	  
 	  <div class="main_content">
-		<h2 class="text-center">{{courses[0].course_department}} {{courses[0].course_number}} {{courses[0].course_name}}</h2>
-		
-		<!-- TODO: update tables to pull real information from database and create related modals -->
-		<!-- Collapsable table views -->
-		<div id="collapse-container">
-			<div class="text-center mb-2">
-				<button type="button" class="btn btn-sm btn-secondary" data-toggle="collapse" data-target="#student-view">View Students</button>
-
-				<button type="button" class="btn btn-sm btn-secondary" data-toggle="collapse" data-target="#swp-view">View Work Products</button>
-			</div>
-			
-			<!-- Student View -->
-			<div class="collapse" id="student-view" data-parent="#collapse-container">
-				<h4 class="text-center">Students</h4>
-				<div class="table-responsive">
-					<table class="table table-bordered mx-auto w-auto text-center">
-						<thead>
-							<tr>
-								<th scope="col">Student Name</th>
-								<th scope="col">Student ID</th>
-								{% if swps %}
-									{% for swp in swps %}
-									<th><a data-toggle="modal" href="#edit-swp-modal{{swp.swp_id}}">{{swp.swp_name}}</a></th>
-									{% endfor %}
-								{% endif %}
-							</tr>
-						</thead>
-						<tbody>
-							{% for student in students %}
-								<tr>
-									<td><a data-toggle="modal" href="#edit-student-modal{{student.student_id}}">{{student.student_first}} {{student.student_last}}</a></td>
-									<td>{{student.student_id}}</td>
-									{% if student.student_scores %}
-										{% for score in student.student_scores %}
-											<td>{{score.score}}</td>
-										{% endfor%}
-									{% endif %}
-								</tr>
+		  <div class="text-center">
+				<h2 class="text-center">{{courses[0].course_department}} {{courses[0].course_number}} {{courses[0].course_name}}</h2>
+				<button type="button" class="btn btn-secondary mb-1">Edit Scores</button>
+		  </div>
+		<div class="table-responsive">
+			<table class="table table-bordered mx-auto w-auto text-center">
+				<thead>
+					<tr>
+						<th scope="col">Student Name</th>
+						<th scope="col">Student ID</th>
+						{% if swps %}
+							{% for swp in swps %}
+								<th><a data-toggle="modal" href="#edit-swp-modal{{swp.swp_id}}">{{swp.swp_name}}</a></th>
 							{% endfor %}
-						</tbody>
-					</table>
-				</div>
-			</div>
-			
-			<!-- SWP View -->
-			<div class="collapse" id="swp-view" data-parent="#collapse-container">
-				<h4 class="text-center">Student Work Products</h4>
-				<div class="table-responsive">
-					<table class="table table-bordered mx-auto w-auto text-center">
-						<thead>
-							<tr>
-								<th scope="col">SWP Name</th>
-								<th scope="col">SWP ID</th>
-							</tr>
-						</thead>
-						<tbody>
-							{% if swps %}				
-								{% for swp in swps %}
-									<tr>
-										<td><a data-toggle="modal" href="#edit-swp-modal{{swp.swp_id}}">{{swp.swp_name}}</a></td>
-										<td>{{swp.swp_id}}</td>
-									</tr>
-									{% endfor %}
-							{% else %}
-								<tr>
-									<td>None ADD BUTTON HERE</td>
-								</tr>
+						{% endif %}
+					</tr>
+				</thead>
+				<tbody>
+					{% for student in students %}
+						<tr>
+							<td><a data-toggle="modal" href="#edit-student-modal{{student.student_id}}">{{student.student_first}} {{student.student_last}}</a></td>
+							<td>{{student.student_id}}</td>
+							{% if student.student_scores %}
+								{% for score in student.student_scores %}
+									<td>{{score.score}}</td>
+								{% endfor%}
 							{% endif %}
-						</tbody>
-					</table>
-				</div>
-			</div>
+						</tr>
+					{% endfor %}
+				</tbody>
+			</table>
 		</div>
-	</div>
+	  </div>
 	
 	<!-- Modals -->
 	

--- a/templates/root_home.html
+++ b/templates/root_home.html
@@ -50,7 +50,7 @@
 						<div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
 							<a class="dropdown-item" href="/registration_requests">Registration Requests</a>
 							<a class="dropdown-item" href="/manage_users">Manage Users</a>
-							<a class="dropdown-item" href="/edit_courses">Edit Courses</a>
+							<a class="dropdown-item" href="/courses/edit">Edit Courses</a>
 							<a class="dropdown-item" href="/edit_student_outcomes">Edit Student Outcomes</a>
 							<a class="dropdown-item" href="/generate_report">Generate Report</a>
 						</div>


### PR DESCRIPTION
Minor styling to edit courses page

Added dropdowns to add course modal(list of terms and list of instructors) for ease of use and less chance of error (i.e. user types "spring" instead of "SPRING")

Made edit course modal hold default values of course clicked (less typing for user)

Added delete course modal (I think this is ready to go, just needs endpoint working)

Removed separate swp view from course page (all actions can be done from single view anyways)